### PR TITLE
removed <b> tag from site_name in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Meta<b>IITGandhinagar</b>
+site_name: Meta IITGandhinagar
 site_url: https://example.com/
 repo_url: https://github.com/OpenSource-IITGn/metaiitgn
 theme:


### PR DESCRIPTION
fixed weird looking title of the webpages. Fixes OpenSource-IITGn/metaiitgn#10
---
changed `site_name:  Meta <b>IITGandhinagar</b>` to `site_name:  Meta IITGandhinagar`  in `mkdocs.yml`   
- build files (`/site`) need to be rebuilt before publishing this change
---
iitgn roll_number : 23110279